### PR TITLE
embedding dropout

### DIFF
--- a/transformer.py
+++ b/transformer.py
@@ -173,12 +173,14 @@ class Encoder():
 				layers=6, dropout=0.1, word_emb=None, pos_emb=None):
 		self.emb_layer = word_emb
 		self.pos_layer = pos_emb
+		self.emb_dropout = Dropout(dropout)
 		self.layers = [EncoderLayer(d_model, d_inner_hid, n_head, d_k, d_v, dropout) for _ in range(layers)]
 	def __call__(self, src_seq, src_pos, return_att=False, active_layers=999):
 		x = self.emb_layer(src_seq)
 		if src_pos is not None:
 			pos = self.pos_layer(src_pos)
 			x = Add()([x, pos])
+		x = self.emb_dropout(x)
 		if return_att: atts = []
 		mask = Lambda(lambda x:GetPadMask(x, x))(src_seq)
 		for enc_layer in self.layers[:active_layers]:


### PR DESCRIPTION
Dropout is supposed to be applied to the embeddings, before the encoder layers. See: https://github.com/tensorflow/models/blob/master/official/transformer/model/transformer.py#L124